### PR TITLE
adds architecture and custom repository support

### DIFF
--- a/docker/build-docker.sh.hbs
+++ b/docker/build-docker.sh.hbs
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -e
 set +x
+
 {{#if dryRun}}
 echo Not logging in to Docker when in dry run mode
 {{else}}
-docker login -u {{dockerUser}} -p {{dockerPassword}}
+docker login -u {{dockerUser}} -p "{{dockerPassword}}" {{dockerRegistryPath}}
 {{/if}}
 
 to_file=builddir/{{cliname}}.jar
@@ -15,7 +16,7 @@ curl {{repositoryUrl}}/{{mavenGroupSlashes}}/{{cliname}}/{{version}}/{{cliname}}
 
 
 echo Building Docker image
-docker rmi -f {{dockerUser}}/{{cliname}}:{{version}} \
+docker rmi -f {{#if dockerRegistryPath}}{{dockerRegistryPath}}{{else}}{{dockerUser}}{{/if}}/{{dockerImageName}}:{{version}} \
  || echo No previous image existed
 
 {{#if architecture}}
@@ -24,7 +25,7 @@ docker buildx build \
 {{else}}
 docker build \
 {{/if}}
- -t {{dockerUser}}/{{cliname}}:{{version}} builddir
+ -t {{#if dockerRegistryPath}}{{dockerRegistryPath}}{{else}}{{dockerUser}}{{/if}}/{{dockerImageName}}:{{version}} builddir
 
 
 echo Push image
@@ -33,9 +34,9 @@ docker images
 {{#if dryRun}}
 echo Not pushing when in dry run mode
 {{else}}
-docker push {{dockerUser}}/{{cliname}}:{{version}}
+docker push {{#if dockerRegistryPath}}{{dockerRegistryPath}}{{else}}{{dockerUser}}{{/if}}/{{dockerImageName}}:{{version}}
 
-
+{{#if updateReadme}}
 echo Update README.md
 readmeFile=README.md
 if [ -f "$readmeFile" ]; then
@@ -48,9 +49,10 @@ if [ -f "$readmeFile" ]; then
     --file /myvol/README.md \
     --short "{{shortDescription}}" \
     --debug \
-    {{dockerUser}}/{{cliname}}
+    {{#if dockerRegistryPath}}{{dockerRegistryPath}}{{else}}{{dockerUser}}{{/if}}/{{dockerImageName}}
 else
     echo "$readmeFile does not exist, not adding readme. Have a README.md in CWD if you want it added."
     ls
 fi
+{{/if}}
 {{/if}}

--- a/docker/build-docker.sh.hbs
+++ b/docker/build-docker.sh.hbs
@@ -10,14 +10,20 @@ docker login -u {{dockerUser}} -p {{dockerPassword}}
 to_file=builddir/{{cliname}}.jar
 echo Downloading {{version}} to $to_file
 rm -f $to_file
-curl https://repo1.maven.org/maven2/{{mavenGroupSlashes}}/{{cliname}}/{{version}}/{{cliname}}-{{version}}.jar \
+curl {{repositoryUrl}}/{{mavenGroupSlashes}}/{{cliname}}/{{version}}/{{cliname}}-{{version}}.jar \
  --output $to_file
 
 
 echo Building Docker image
 docker rmi -f {{dockerUser}}/{{cliname}}:{{version}} \
  || echo No previous image existed
+
+{{#if architecture}}
+docker buildx build \
+ --platform {{architecture}} \
+{{else}}
 docker build \
+{{/if}}
  -t {{dockerUser}}/{{cliname}}:{{version}} builddir
 
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,17 @@ const program = new Command()
     'Given if the JAR should be compiled with GraalVM to native binary',
     false
   )
-  .option('--dry-run', 'Given if nothing should be done, just printed', false);
+  .option('--dry-run', 'Given if nothing should be done, just printed', false)
+  .option(
+    '--architecture <architecture>',
+    'Choose what architecture(s) to build for',
+    (value: string, previous: string) => previous?.concat(`,${value}`) ?? value
+  )
+  .option(
+    '--repository-url <url>',
+    'The URL that the library exists at',
+    'https://repo1.maven.org/maven2'
+  );
 
 program.parse(process.argv);
 
@@ -37,80 +47,90 @@ console.log(
 
 const mavenGroupSlashes = options.mavenGroup.replaceAll('.', '/');
 
-const pomUrl = `https://repo1.maven.org/maven2/${mavenGroupSlashes}/${options.mavenArtifact}/${options.mavenVersion}/${options.mavenArtifact}-${options.mavenVersion}.pom`;
+const pomUrl = `${options.repositoryUrl}/${mavenGroupSlashes}/${options.mavenArtifact}/${options.mavenVersion}/${options.mavenArtifact}-${options.mavenVersion}.pom`;
+const url = new URL(pomUrl);
+
 console.log(`Getting ${pomUrl}`);
-fetch(pomUrl).then((response: any) => {
-  response.text().then((pomXmlString: string) => {
-    const parser = new XMLParser();
-    let pomXmlObject = parser.parse(pomXmlString);
-    const pomDescription = pomXmlObject.project.description;
+(url.protocol === 'file:' ? fs.promises.readFile(url) : fetch(url)).then(
+  (response: any) => {
+    const startBuild = (pomXmlString: string) => {
+      const parser = new XMLParser();
+      let pomXmlObject = parser.parse(pomXmlString);
+      const pomDescription = pomXmlObject.project.description;
 
-    const context: Context = {
-      cliname: options.mavenArtifact,
-      mavenGroupSlashes: mavenGroupSlashes,
-      version: options.mavenVersion,
-      dockerUser: options.dockerUsername,
-      dockerPassword: options.dockerPassword,
-      shortDescription: pomDescription,
-      compileNative: options.compileNative,
-      dryRun: options.dryRun,
-    };
+      const context: Context = {
+        cliname: options.mavenArtifact,
+        mavenGroupSlashes: mavenGroupSlashes,
+        version: options.mavenVersion,
+        dockerUser: options.dockerUsername,
+        dockerPassword: options.dockerPassword,
+        shortDescription: pomDescription,
+        compileNative: options.compileNative,
+        dryRun: options.dryRun,
+        architecture: options.architecture,
+        repositoryUrl: options.repositoryUrl,
+      };
 
-    const workFolder = os.tmpdir() + '/' + crypto.randomUUID();
-    fs.mkdirSync(`${workFolder}`);
-    fs.mkdirSync(`${workFolder}/builddir`);
-    console.log(`Working in ${workFolder}`);
-    console.log(
-      `Context: ${JSON.stringify(
-        { ...context, dockerPassword: '***' },
-        null,
-        4
-      )}`
-    );
-
-    const render = function (
-      templateFile: string,
-      context: Context,
-      targetFolder: string
-    ) {
-      const source = fs.readFileSync(
-        path.resolve(__dirname, '..', 'docker', `${templateFile}.hbs`)
+      const workFolder = os.tmpdir() + '/' + crypto.randomUUID();
+      fs.mkdirSync(`${workFolder}`);
+      fs.mkdirSync(`${workFolder}/builddir`);
+      console.log(`Working in ${workFolder}`);
+      console.log(
+        `Context: ${JSON.stringify(
+          { ...context, dockerPassword: '***' },
+          null,
+          4
+        )}`
       );
 
-      const template = Handlebars.compile(`${source}`);
-      const result = template(context);
-      const file = `${targetFolder}/${templateFile}`;
-      if (context) {
-        console.log(file + '\n' + result + '\n');
+      const render = function (
+        templateFile: string,
+        context: Context,
+        targetFolder: string
+      ) {
+        const source = fs.readFileSync(
+          path.resolve(__dirname, '..', 'docker', `${templateFile}.hbs`)
+        );
+
+        const template = Handlebars.compile(`${source}`);
+        const result = template(context);
+        const file = `${targetFolder}/${templateFile}`;
+        if (context) {
+          console.log(file + '\n' + result + '\n');
+        }
+        fs.writeFileSync(file, result);
+      };
+
+      render('build-docker.sh', context, `${workFolder}`);
+      render('builddir/bin', context, `${workFolder}`);
+      render('builddir/Dockerfile', context, `${workFolder}`);
+
+      const fromReadme = path.resolve(process.cwd(), 'README.md');
+      if (fs.existsSync(fromReadme)) {
+        console.log(`Copying ${fromReadme} to ${workFolder}`);
+        fs.copyFileSync(fromReadme, path.resolve(workFolder, 'README.md'));
+      } else {
+        console.log(`Not copying ${fromReadme} to ${workFolder}`);
       }
-      fs.writeFileSync(file, result);
+
+      const spawnedBuildDocker = spawn(
+        'sh',
+        ['build-docker.sh', options.mavenVersion],
+        { cwd: workFolder }
+      );
+      spawnedBuildDocker.stdout.on('data', function (data) {
+        console.log('stdout: ' + data.toString());
+      });
+      spawnedBuildDocker.stderr.on('data', function (data) {
+        console.log('stderr: ' + data.toString());
+      });
+      spawnedBuildDocker.on('exit', function (code) {
+        console.log('child process exited with code ' + code);
+      });
     };
 
-    render('build-docker.sh', context, `${workFolder}`);
-    render('builddir/bin', context, `${workFolder}`);
-    render('builddir/Dockerfile', context, `${workFolder}`);
-
-    const fromReadme = path.resolve(process.cwd(), 'README.md');
-    if (fs.existsSync(fromReadme)) {
-      console.log(`Copying ${fromReadme} to ${workFolder}`);
-      fs.copyFileSync(fromReadme, path.resolve(workFolder, 'README.md'));
-    } else {
-      console.log(`Not copying ${fromReadme} to ${workFolder}`);
-    }
-
-    const spawnedBuildDocker = spawn(
-      'sh',
-      ['build-docker.sh', options.mavenVersion],
-      { cwd: workFolder }
-    );
-    spawnedBuildDocker.stdout.on('data', function (data) {
-      console.log('stdout: ' + data.toString());
-    });
-    spawnedBuildDocker.stderr.on('data', function (data) {
-      console.log('stderr: ' + data.toString());
-    });
-    spawnedBuildDocker.on('exit', function (code) {
-      console.log('child process exited with code ' + code);
-    });
-  });
-});
+    return url.protocol === 'file:'
+      ? startBuild(Buffer.from(response).toString())
+      : response.text().then(startBuild);
+  }
+);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,7 +37,7 @@ const program = new Command()
   )
   .option('--dry-run', 'Given if nothing should be done, just printed', false)
   .option(
-    '--architecture <architecture>',
+    '--architecture <architectures...>',
     'Choose what architecture(s) to build for',
     (value: string, previous: string) => previous?.concat(`,${value}`) ?? value
   )

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,9 +4,12 @@ export interface Context {
   version: string;
   dockerUser: string;
   dockerPassword: string;
+  dockerRegistryPath: string;
+  dockerImageName: () => string;
   shortDescription: string;
   compileNative: boolean;
   dryRun: boolean;
   architecture: string;
   repositoryUrl: string;
+  updateReadme: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,4 +7,6 @@ export interface Context {
   shortDescription: string;
   compileNative: boolean;
   dryRun: boolean;
+  architecture: string;
+  repositoryUrl: string;
 }


### PR DESCRIPTION
Hello hello, long time no talk! I submitted a PR ages ago adding in support for custom fields, and i'm back again after some of my users switched to running their CI/CD through arm64 instances. Currently only one architecture type is supported, whatever your machine is on, but this'll let you use buildx to build for more (git-changelog-command-line's image currently is only amd64, but multi-arch support is easy since it's a java app :) ).
I also added in loading from a custom repository, because I wanted to test it locally, and there might be an opportunity to take this a step further someday and add a "--repository-password" flag for authenticated downloads (i'm thinking artifactory, which we use). 

I've also added in custom image name, registry path, and no readme update support. Here's an example with it all, that I have used for my real-actual push!

`npm run build \
 && node ./lib/cli.js \
 --docker-username AWS \
 --docker-password "MYVERYLONGAWSECRJWTPASSWORD" \
 --docker-registry-path MYECRID.dkr.ecr.us-east-1.amazonaws.com/MYECRSUBPATH \
 --docker-image-name "tomasbjerre-{{ cliname }}" \
 --maven-group se.bjurr.gitchangelog \
 --maven-artifact git-changelog-command-line \
 --maven-version 2.3.0 \
 --architecture linux/amd64,linux/arm64/v8 \
 --repository-url file:///Users/ME/.m2/repository \
 --no-update-readme`